### PR TITLE
Fixed styling on popup boxes on dark mode machines

### DIFF
--- a/meshtastic_tkinter_app.py
+++ b/meshtastic_tkinter_app.py
@@ -9,6 +9,7 @@ from Class.meshtastic_chat_app import MeshtasticChatApp  # Import your existing 
 import platform
 
 CHUNK_SIZE = 100  # Define CHUNK_SIZE here
+STYLE = 'default'  # Set the style to be used for the ttk widgets
 
 class ScrollableFrame(ttk.Frame):
     def __init__(self, container, *args, **kwargs):
@@ -31,11 +32,14 @@ class ScrollableFrame(ttk.Frame):
         canvas.pack(side="left", fill="both", expand=True)
         scrollbar.pack(side="right", fill="y")
         style = ttk.Style()
-        style.theme_use("default")
+        style.theme_use(STYLE)
 
 class MeshtasticTkinterApp:
     def __init__(self, master):
         self.master = master
+        self.master.option_add("*Background", "white")
+        self.master.option_add("*Foreground", "black")
+        self.master.option_add("*Entry*background", "white")
         self.master.title("Meshtastic Chat App")
 
         # Create a menu bar
@@ -480,7 +484,7 @@ class MeshtasticTkinterApp:
         
         dest_id = self.destination_id.get()
         try:
-            hop_limit = int(simpledialog.askstring("Trace Route", "Enter hop limit:"))
+            hop_limit = int(simpledialog.askinteger("Trace Route", "Enter hop limit:"))
         except ValueError:
             messagebox.showerror("Error", "Invalid hop limit")
             return


### PR DESCRIPTION
 - Fixed style of selection boxes on mac and standardized the color scheme for the application using the option_add method of the root tab
 - Changed hop_limit box to ask for an integer instead of a string to prevent accidental entries